### PR TITLE
Implement getLiveMarketIds() helper function, call LiveMarketCatalogue API 

### DIFF
--- a/fanduelOdds.php
+++ b/fanduelOdds.php
@@ -1,0 +1,103 @@
+<?php
+
+class FanduelOdds {
+    public $liveMarketsEndpoint;
+    public $liveMarketPricesEndpoint;
+    private $secret_key;
+
+    const BASKETBALL_ID = "7522";
+    const NBA_ID = "10547864";
+    const RAPTORS_ID = ""; //TODO: fill out with value from Confluence doc 
+  
+    const MARKET_TYPES = ["MATCH_HANDICAP_(2-WAY)","MONEY_LINE","TOTAL_POINTS_(OVER/UNDER)"];
+
+    // Constructor 
+    public function __construct($secret_key, $liveMarketsEndpoint="https://affiliates.sportsbook.fanduel.com/betting/rest/v1/listMarketCatalogue/", 
+    $liveMarketPricesEndpoint="https://affiliates.sportsbook.fanduel.com/betting/rest/v1/listMarketPrices/") {
+        $this->liveMarketsEndpoint = $liveMarketsEndpoint;
+        $this->liveMarketPricesEndpoint = $liveMarketPricesEndpoint;
+        $this->secret_key = $secret_key;
+    }
+
+    public function getHtml() {
+        /**
+         * Returns a table (in HTML) of prices for the next Raptors game
+         *
+         * @param
+         * @return HTML the corresponding prices table 
+         */
+        
+        $html = '
+            <div>
+                <h1>Welcome to My Website</h1>
+                <p>This is an example of returning HTML from a PHP function.</p>
+            </div>
+        ';
+
+        return $html;
+    }
+
+    public function getLiveMarketIds() {
+        /**
+         * Helper function that returns ids of all live NBA markets. Calls the $liveMarketsEndpoint
+         *
+         * @return array Array of live market ids
+         */
+
+        $liveMarketsRequestPayload = json_encode([
+            "listMarketCatalogueRequestParams" => [
+                "marketFilter" => [
+                    "eventTypeIds" => [self::BASKETBALL_ID],
+                    "competitionIds" => [self::NBA_ID],
+                    "marketTypes" => self::MARKET_TYPES
+                ],
+                "maxResults" => 1000
+            ]
+        ]);
+        
+        $requestHeaders = [
+            "Content-type: application/json",
+            "X-Application: " . $this->secret_key
+        ];
+
+        $liveMarketsCh = curl_init();
+
+        curl_setopt_array($liveMarketsCh, [
+            CURLOPT_URL => $this->liveMarketsEndpoint,
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_CUSTOMREQUEST => "POST",
+            CURLOPT_POSTFIELDS => $liveMarketsRequestPayload,
+            CURLOPT_HTTPHEADER => $requestHeaders
+        ]);
+
+        $liveMarketsResponse = curl_exec($liveMarketsCh);
+
+        if (curl_errno($liveMarketsCh)) {
+            echo 'Error: ' . curl_error($liveMarketsCh);
+            curl_close($liveMarketsCh);
+            return [];
+        } 
+        else {
+            $data = json_decode($liveMarketsResponse);
+            $liveMarketIds = [];
+            foreach ($data as $item) {
+                array_push($liveMarketIds, $item->marketId);
+
+                // echo "Market ID: " . $item->marketId . PHP_EOL;
+                // echo "Market Name: " . $item->marketName . "\n";
+                // echo "Market Start Time: " . $item->marketStartTime . "\n";
+                // echo "--------------------------\n";
+            }
+            curl_close($liveMarketsCh);
+            return $liveMarketIds;
+        }
+    }
+    private function getMarketPrices() {
+        /**
+         * Helper function that returns market prices for Spread Betting, Money Line and Total Points for next Raptors game
+         *
+         * @return array Array of market prices for next Raptors game
+         */
+        return [];
+    }
+}

--- a/fanduelOdds.php
+++ b/fanduelOdds.php
@@ -26,24 +26,34 @@ class FanduelOdds {
          * @param
          * @return HTML the corresponding prices table 
          */
-        
-        $html = '
-            <div>
-                <h1>Welcome to My Website</h1>
-                <p>This is an example of returning HTML from a PHP function.</p>
-            </div>
-        ';
 
-        return $html;
+        
+        $liveMarketIds = $this->getLiveMarketIds();
+        print_r($liveMarketIds);
+
+        if (count($liveMarketIds) == 0) {
+            // there was some error fetching liveMarketIds
+            return '';
+        }
+        else {
+            //TODO: call getMarketPrices() and create table with relevant prices here 
+            $html = '
+                <div>
+                    <h1>Test</h1>
+                </div>
+            ';
+            return $html;
+        }       
     }
 
-    public function getLiveMarketIds() {
+    private function getLiveMarketIds() {
         /**
          * Helper function that returns ids of all live NBA markets. Calls the $liveMarketsEndpoint
          *
          * @return array Array of live market ids
          */
 
+        // setup request to ListMarketCatalogue API
         $liveMarketsRequestPayload = json_encode([
             "listMarketCatalogueRequestParams" => [
                 "marketFilter" => [
@@ -72,21 +82,18 @@ class FanduelOdds {
 
         $liveMarketsResponse = curl_exec($liveMarketsCh);
 
+        // process the response
         if (curl_errno($liveMarketsCh)) {
-            echo 'Error: ' . curl_error($liveMarketsCh);
+            echo 'Error (getLiveMarketIds): ' . curl_error($liveMarketsCh);
             curl_close($liveMarketsCh);
             return [];
         } 
         else {
             $data = json_decode($liveMarketsResponse);
             $liveMarketIds = [];
+            // grab all liveMarketIds
             foreach ($data as $item) {
                 array_push($liveMarketIds, $item->marketId);
-
-                // echo "Market ID: " . $item->marketId . PHP_EOL;
-                // echo "Market Name: " . $item->marketName . "\n";
-                // echo "Market Start Time: " . $item->marketStartTime . "\n";
-                // echo "--------------------------\n";
             }
             curl_close($liveMarketsCh);
             return $liveMarketIds;

--- a/index.php
+++ b/index.php
@@ -2,8 +2,8 @@
 
 require_once 'fanduelOdds.php';
 
-$fanduel = new FanduelOdds("Y92oEkhNW2osW6tS");
+$fanduel = new FanduelOdds(/* Secret Key */);
 
-print_r($fanduel->getLiveMarketIds());
+print_r($fanduel->getHtml());
 
 

--- a/index.php
+++ b/index.php
@@ -1,0 +1,9 @@
+<?php
+
+require_once 'fanduelOdds.php';
+
+$fanduel = new FanduelOdds("Y92oEkhNW2osW6tS");
+
+print_r($fanduel->getLiveMarketIds());
+
+


### PR DESCRIPTION
- implement helper function that returns ids of all live NBA markets. 


**Testing**: sample usage in `index.php`.
- Run ` php -S 127.0.0.1:8000` locally and navigate to `localhost:8000`, the output should look like this: 
    - Array printed is the live NBA markets retrieved from LiveMarketCatalogue API 
    - "Test" output is the current dummy return value of `getHtml()` function
![image](https://github.com/chen-jonathan/fanduel_integration/assets/53841219/0b7180f6-a90c-4494-9606-40ede9c307da)
